### PR TITLE
Atomic Conditional Updates

### DIFF
--- a/perf/combine.js
+++ b/perf/combine.js
@@ -3,6 +3,7 @@ const Rythe = require("../dist/cjs/index");
 const rxjs = require("rxjs");
 const rxOps = require("rxjs/operators");
 const flyd = require("flyd");
+const flydFilter = require("flyd/module/filter");
 const utils = require("./utils");
 
 const suite1 = new Benchmark.Suite();
@@ -15,6 +16,9 @@ const mapD = val => val + "d";
 const liftAB = (a, b) => a + b + "c";
 const liftBC = (b, c) => b + c + "e";
 const liftDE = (a, d, e) => a + d + e + "f";
+
+const conditionalABC = (sA, sB, sC) => sA() + sB() + sC();
+const conditionalDEF = (d, e, f) => d + e + f;
 
 let output;
 
@@ -54,9 +58,43 @@ const defineCombinedStream = () => {
   return { inputs: sources, output: sF };
 };
 
+const defineConditionalRythe = () => {
+  const s = Rythe.createStream();
+  const a = s.pipe(Rythe.filter(value => value % 2 === 0));
+  const b = s.pipe(Rythe.filter(value => value < 3 || value > 4));
+  const c = s.pipe(Rythe.filter(value => value !== 3));
+  const o = Rythe.combine(conditionalABC, [a, b, c]);
+  return { input: s, o };
+};
+
+const defineConditionalSubject = () => {
+  const s = new rxjs.Subject();
+  const d = s.pipe(rxOps.filter(value => value % 2 === 0));
+  const e = s.pipe(rxOps.filter(value => value < 3 || value > 4));
+  const f = s.pipe(rxOps.filter(value => value !== 3));
+  const o = s.pipe(rxOps.combineLatest([d, e, f], conditionalDEF));
+  o.subscribe(value => {
+    output = value;
+  });
+  return { input: s, o };
+};
+
+const defineConditionalStream = () => {
+  const s = flyd.stream();
+  const a = flydFilter(value => value % 2 === 0, s);
+  const b = flydFilter(value => value < 3 || value > 4, s);
+  const c = flydFilter(value => value !== 3, s);
+  const o = flyd.combine(conditionalABC, [a, b, c]);
+  return { input: s, o };
+};
+
 const rytheObj = defineCombinedRythe();
 const subjectObj = defineCombinedSubject();
 const streamObj = defineCombinedStream();
+
+const rytheConditional = defineConditionalRythe();
+const subjectConditional = defineConditionalSubject();
+const streamConditional = defineConditionalStream();
 
 console.log("\nDefining Complex Combine Deps");
 suite1
@@ -89,6 +127,30 @@ suite2
     a("a");
     b("b");
     a("A");
+  })
+  .on("cycle", ev => console.log(ev.target.toString()))
+  .on("complete", function() {
+    utils.printFastest(this);
+  })
+  .run({ defer: true });
+
+console.log("Resolving Conditional Combine Deps");
+const suite3 = new Benchmark.Suite();
+suite3
+  .add("Combine Rythe Streams", () => {
+    const { input } = rytheConditional;
+    input(2)(3)(4)(5);
+  })
+  .add("Combine Subjects", () => {
+    const { input } = subjectConditional;
+    input.next(2);
+    input.next(3);
+    input.next(4);
+    input.next(5);
+  })
+  .add("Combine Flyd Streams", () => {
+    const { input } = streamConditional;
+    input(2)(3)(4)(5);
   })
   .on("cycle", ev => console.log(ev.target.toString()))
   .on("complete", function() {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,13 +6,17 @@
  * 3. CHANGING
  */
 export enum StreamState {
+  /** Stream is closed. Will no longer emit values. */
   CLOSED,
+  /** Stream is pending. Waiting to receive its first value. */
   PENDING,
+  /** Stream is active. Has received a value and ready to emit. */
   ACTIVE,
+  /** Stream is changing. Has been marked to receive a new value. */
   CHANGING
 }
 
-export enum StreamError {
-  SOURCE_ERROR = "Source(s) must be a Stream function",
-  PIPE_ERROR = "Can't pipe with no functions"
-}
+export const StreamError = {
+  SOURCE_ERROR: "Source(s) must be a Stream function",
+  PIPE_ERROR: "Can't pipe with no functions"
+} as const;

--- a/src/dispatchers/dispatcherHelpers.ts
+++ b/src/dispatchers/dispatcherHelpers.ts
@@ -1,5 +1,4 @@
 import { StreamState } from "../constants";
-import { END, SKIP } from "../signal";
 import { Stream } from "../types";
 
 const { ACTIVE, CHANGING, PENDING } = StreamState;
@@ -15,28 +14,14 @@ export const markActive = (stream: Stream<any>): void => {
  * Mark all Stream Dependencies recursively. Goes from newest dependency to old,
  * skipping those that have been marked already.
  */
-export const markDependencies = (stream: Stream<any>): void => {
+export const markAsChanging = (stream: Stream<any>): void => {
   const { state, dependents } = stream;
   for (let i = dependents.length; i--; ) {
     const [dep] = dependents[i];
     dep.waiting += state === PENDING ? 0 : 1;
     if (dep.state !== CHANGING) {
-      markDependencies(dep);
+      markAsChanging(dep);
     }
   }
   stream.state = CHANGING;
-};
-
-/**
- * Checks the incoming value for END or SKIP signals, otherwise it updates the stream
- * value and returns true to initiate a broadcast.
- */
-export const shouldApplyValue = <T>(stream: Stream<T>, value: T): boolean => {
-  if (value === END) {
-    stream.end(true);
-  } else if (value !== SKIP) {
-    stream.val = value;
-    return true;
-  }
-  return false;
 };

--- a/src/dispatchers/dispatcherHelpers.ts
+++ b/src/dispatchers/dispatcherHelpers.ts
@@ -3,7 +3,7 @@ import { Stream } from "../types";
 
 const { ACTIVE, CHANGING, PENDING } = StreamState;
 
-export const isReady = (stream: Stream<any>): boolean => !--stream.waiting;
+export const isReady = (stream: Stream<any>): boolean => !(stream.waiting -= 1);
 
 /** Mark a Stream as ACTIVE */
 export const markActive = (stream: Stream<any>): void => {

--- a/src/dispatchers/recursiveDispatcher.ts
+++ b/src/dispatchers/recursiveDispatcher.ts
@@ -1,29 +1,38 @@
 import { Stream, DependentTuple, Dispatcher } from "../types";
-import {
-  isReady,
-  markActive,
-  markDependencies,
-  shouldApplyValue
-} from "./dispatcherHelpers";
+import { isReady, markActive, markAsChanging } from "./dispatcherHelpers";
+import { END, SKIP, isSignal } from "../signal";
 
-const hasDependencies = <T>(stream: Stream<T>): void => {
+const pushUpdate = <T>(stream: Stream<T>, updating: boolean): void => {
   markActive(stream);
   const { dependents, val } = stream;
   if (dependents.length) {
     // Recursive, so it has to rely on hoisting.
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    updateDependencies(val, dependents);
+    updateDependencies(val, dependents, updating);
   }
 };
 
 const updateDependencies = <T>(
   value: T,
-  deps: DependentTuple<T, any>[]
+  deps: DependentTuple<T, any>[],
+  updating: boolean
 ): void => {
   for (let i = deps.length; i--; ) {
     const [dep, fn] = deps[i];
-    if (isReady(dep) && shouldApplyValue(dep, fn(value))) {
-      hasDependencies(dep);
+    if (isReady(dep)) {
+      const newValue = updating || dep.updating ? fn(value) : SKIP;
+      if (isSignal(newValue)) {
+        pushUpdate(dep, false);
+        if (newValue === END) {
+          dep.end(true);
+        }
+      } else {
+        dep.val = newValue;
+        pushUpdate(dep, true);
+      }
+      dep.updating = 0;
+    } else if (updating) {
+      dep.updating++;
     }
   }
 };
@@ -37,8 +46,13 @@ export const recursiveDispatcher: Dispatcher = <T>(
   stream: Stream<T>,
   value: T
 ): void => {
-  if (shouldApplyValue(stream, value) && stream.state) {
-    markDependencies(stream);
-    hasDependencies(stream);
+  if (!isSignal(value)) {
+    stream.val = value;
+    if (stream.state) {
+      markAsChanging(stream);
+      pushUpdate(stream, true);
+    }
+  } else if (value === END) {
+    stream.end(true);
   }
 };

--- a/src/dispatchers/recursiveDispatcher.ts
+++ b/src/dispatchers/recursiveDispatcher.ts
@@ -32,7 +32,7 @@ const updateDependencies = <T>(
       }
       dep.updating = 0;
     } else if (updating) {
-      dep.updating++;
+      dep.updating += 1;
     }
   }
 };

--- a/src/operators/combine.ts
+++ b/src/operators/combine.ts
@@ -4,19 +4,6 @@ import { Stream, DependentTuple } from "../types";
 
 const { PENDING } = StreamState;
 
-function applyDepTuple(
-  this: DependentTuple<any, any>,
-  source: Stream<any>
-): void {
-  const { dependents, state } = source;
-  const [combinedStream] = this;
-  if (!isStream(source)) {
-    throw new Error(StreamError.SOURCE_ERROR);
-  }
-  dependents.push(this);
-  combinedStream.waiting += state === PENDING ? 1 : 0;
-}
-
 /**
  * Combines many Stream sources into a single output.
  */
@@ -32,7 +19,15 @@ export function combine<T extends Stream<any>[], U>(
   ];
 
   // Many Parents to One Stream Subscription
-  sources.forEach(applyDepTuple, depTuple);
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i];
+    const { dependents, state } = source;
+    if (!isStream(source)) {
+      throw new Error(StreamError.SOURCE_ERROR);
+    }
+    dependents.push(depTuple);
+    combinedStream.waiting += state === PENDING ? 1 : 0;
+  }
 
   if (sources.length && !combinedStream.waiting) {
     combinedStream(combineFn(...sources));

--- a/src/operators/combine.ts
+++ b/src/operators/combine.ts
@@ -19,7 +19,7 @@ export function combine<T extends Stream<any>[], U>(
   ];
 
   // Many Parents to One Stream Subscription
-  for (let i = 0; i < sources.length; i++) {
+  for (let i = sources.length; i--; ) {
     const source = sources[i];
     const { dependents, state } = source;
     if (!isStream(source)) {

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -11,3 +11,6 @@ export const SKIP: SKIP = freeze(create(null));
  * END. Used for signalling a Stream to close itself when passed as a parameter.
  */
 export const END: END = freeze(create(null));
+
+export const isSignal = (value: any): boolean =>
+  value === SKIP || value === END;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,12 @@ export interface Stream<T> {
    */
   waiting: number;
   /**
+   * Semphore for tracking how many parents need to update while the current stream is
+   * waiting for all parents to resolve.
+   * @internal
+   */
+  updating: number;
+  /**
    * Current State of the Stream. Possible state values:
    * 0. CLOSED: The Stream is closed. It won't notify any dependents nor be updated by any parents.
    * 1. PENDING: The Stream is pending an update. It has not received any values yet.

--- a/tests/operators/filter.test.ts
+++ b/tests/operators/filter.test.ts
@@ -1,6 +1,7 @@
 import { createStream } from "../../src/stream";
 import { StreamState } from "../../src/constants";
-import { filter, map } from "../../src/operators/index";
+import { filter, map, combine, scan } from "../../src/operators/index";
+import { Stream } from "../../src/types";
 
 describe("filter", () => {
   it("is pipeable", () => {
@@ -26,8 +27,14 @@ describe("filter", () => {
     mockFn.mockClear();
     a(5);
     expect(b()).toBe(16);
+    expect(b.waiting).toBe(0);
     expect(mockFn).toBeCalledTimes(0);
+    a(7);
+    expect(b.waiting).toBe(0);
+    expect(b.state).toBe(StreamState.ACTIVE);
     a(2);
+
+    expect(b.waiting).toBe(0);
     expect(b()).toBe(4);
     expect(mockFn).toBeCalledTimes(1);
     expect(mockFn).toBeCalledWith(2);
@@ -41,5 +48,34 @@ describe("filter", () => {
     );
     expect(mockFn).toBeCalledTimes(0);
     expect(b.state).toBe(StreamState.PENDING);
+  });
+  it("will filter atomically", () => {
+    const combineFn = jest.fn(
+      (...args: Stream<number>[]): string => JSON.stringify(args)
+    );
+    const a = createStream<number>();
+    const b = a.pipe(filter(value => value % 2 === 0));
+    const c = a.pipe(filter(value => value < 3 || value > 4));
+    const d = a.pipe(filter(value => value !== 3));
+    const atomic = combine(combineFn, [b, c, d]).pipe(
+      scan<string>(
+        (acc, value) => {
+          acc.push(value);
+          return acc;
+        },
+        [] as string[]
+      )
+    );
+    // All filters will update
+    a(2);
+    expect(combineFn).toBeCalledTimes(1);
+    // All filters should exclude this value
+    a(3);
+    // Two filters will pass this
+    a(4);
+    expect(combineFn).toBeCalledTimes(2);
+    a(5)(6);
+    expect(combineFn).toBeCalledTimes(4);
+    expect(atomic()).toEqual(["[2,2,2]", "[4,2,4]", "[4,5,5]", "[6,6,6]"]);
   });
 });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "../"
   },
   "include": ["./**/*.ts"],
   "exclude": []


### PR DESCRIPTION
Currently, the method to dispatch across all dependencies failed to account for circumstances where a stream subscribed to multiple parents that could emit values conditionally could fail to update correctly depending on order of said updates.

This PR is the changes necessary to allow for atomic updates to occur when a combine is subscribed to multiple parents that can emit SKIPs, no matter the order. If all parents emit SKIP, then the combine does not update. If one or more parents do not emit SKIP, then combine updates. The dependency graph of a given stream will be fully updated from CHANGING back to ACTIVE if updates are received or not as a result of these changes.

Included with these changes are some code tidy-ups, as well as a perf test case for benchmarking conditional updates for a combined stream.