### PR TITLE
Helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,34 @@ A tiny, heavily tree-shakeable Reactive Stream library
 
 ## HEAVY WORK IN PROGRESS
 Do not use for production. You have been warned.
+
+## Installation and Usage
+
+### ES6 via NPM
+
+```
+npm install rythe
+```
+
+```js
+import { createStream } from "rythe";
+import { filter, map } from "rythe/operators";
+
+const stream = createStream();
+
+const mapped = stream.pipe(
+  filter(value => value % 2 !== 0),
+  map(value => value ** 3)
+);
+
+stream(5)(6); // mapped emits only 125, 6 is filtered out
+```
+
+## Goals
+* Provide a tree-shakeable FRP library for use with bundlers like Rollup
+* Have better performance while providing similar ergonomics/API to libraries like Flyd, RxJS
+* Make use of Typescript as the implementation language for the library for better type documentation and interfaces
+
+## Documentation
+
+Coming Soon.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rythe
-[![Build Status](https://api.cirrus-ci.com/github/Bluefinger/rythe.svg)](https://cirrus-ci.com/github/Bluefinger/rythe) [![Coverage Status](https://codecov.io/github/Bluefinger/rythe/coverage.svg?branch=master)](https://codecov.io/github/Bluefinger/rythe/)
+[![ci](https://api.cirrus-ci.com/github/Bluefinger/rythe.svg)](https://cirrus-ci.com/github/Bluefinger/rythe) [![codecov](https://codecov.io/gh/Bluefinger/rythe/branch/master/graph/badge.svg)](https://codecov.io/gh/Bluefinger/rythe) [![npm version](https://badge.fury.io/js/rythe.svg)](https://badge.fury.io/js/rythe)
 
 A tiny, heavily tree-shakeable Reactive Stream library
 

--- a/src/helpers/fromDOMEvent.ts
+++ b/src/helpers/fromDOMEvent.ts
@@ -1,0 +1,49 @@
+import { createStream } from "../stream";
+import { Stream } from "../types";
+import { map } from "../operators/map";
+
+const applyEventStream = (
+  stream: Stream<Event>,
+  targets: NodeList | HTMLCollection,
+  event: string,
+  eventOptions?: EventListenerOptions
+): void => {
+  for (let i = targets.length; i--; ) {
+    const target = targets[i];
+    target.addEventListener(event, stream, eventOptions);
+  }
+};
+
+const removeEventStream = (
+  stream: Stream<Event>,
+  targets: NodeList | HTMLCollection,
+  event: string
+): void => {
+  for (let i = targets.length; i--; ) {
+    const target = targets[i];
+    target.removeEventListener(event, stream);
+  }
+};
+
+const isNode = (node: Node | NodeList | HTMLCollection): node is Node =>
+  (node as any).length === undefined;
+
+export const fromDOMEvent = (
+  target: Node | NodeList | HTMLCollection,
+  event: string,
+  eventOptions?: EventListenerOptions
+): Stream<Event> => {
+  const eventStream = createStream<Event>();
+  let operator: () => void;
+
+  if (!isNode(target)) {
+    applyEventStream(eventStream, target, event, eventOptions);
+    operator = (): void => removeEventStream(eventStream, target, event);
+  } else {
+    target.addEventListener(event, eventStream, eventOptions);
+    operator = (): void => target.removeEventListener(event, eventStream);
+  }
+
+  map<boolean, void>(operator)(eventStream.end);
+  return eventStream;
+};

--- a/src/helpers/fromNodeEvent.ts
+++ b/src/helpers/fromNodeEvent.ts
@@ -1,0 +1,20 @@
+import { createStream } from "../stream";
+import { Stream } from "../types";
+import { map } from "../operators/map";
+import { EventEmitter } from "events";
+
+export const fromNodeEvent = (
+  target: EventEmitter,
+  event: string
+): Stream<any> => {
+  const eventStream = createStream<any>();
+
+  target.on(event, eventStream);
+  map<boolean, void>(
+    (): void => {
+      target.off(event, eventStream);
+    }
+  )(eventStream.end);
+
+  return eventStream;
+};

--- a/src/helpers/fromPromise.ts
+++ b/src/helpers/fromPromise.ts
@@ -1,17 +1,12 @@
 import { createStream } from "../stream";
 import { Stream } from "../types";
 import { END } from "../signal";
-import { noop } from "../utils/noop";
 
-export const fromPromise = <T>(
-  promise: Promise<T>,
-  errorHandler: (reason: any) => void = noop
-): Stream<T> => {
+export const fromPromise = <T>(promise: PromiseLike<T>): Stream<T> => {
   const promiseStream = createStream<T>();
-  promise.then(promiseStream, errorHandler).finally(
-    (): void => {
-      promiseStream(END);
-    }
-  );
+  const end = (): void => {
+    promiseStream(END);
+  };
+  promise.then(promiseStream, end).then(end);
   return promiseStream;
 };

--- a/src/helpers/fromPromise.ts
+++ b/src/helpers/fromPromise.ts
@@ -1,0 +1,17 @@
+import { createStream } from "../stream";
+import { Stream } from "../types";
+import { END } from "../signal";
+import { noop } from "../utils/noop";
+
+export const fromPromise = <T>(
+  promise: Promise<T>,
+  errorHandler: (reason: any) => void = noop
+): Stream<T> => {
+  const promiseStream = createStream<T>();
+  promise.then(promiseStream, errorHandler).finally(
+    (): void => {
+      promiseStream(END);
+    }
+  );
+  return promiseStream;
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,5 @@
+import { fromPromise } from "./fromPromise";
+import { fromDOMEvent } from "./fromDOMEvent";
+import { fromNodeEvent } from "./fromNodeEvent";
+
+export { fromDOMEvent, fromNodeEvent, fromPromise };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { StreamState } from "./constants";
 import { combine, dropRepeats, filter, map, scan } from "./operators/index";
 import { END, SKIP } from "./signal";
 import { Stream, StreamFn, DependentTuple } from "./types";
+import { fromDOMEvent, fromNodeEvent, fromPromise } from "./helpers";
 
 export {
   createStream,
@@ -17,5 +18,8 @@ export {
   SKIP,
   Stream,
   StreamFn,
-  DependentTuple
+  DependentTuple,
+  fromDOMEvent,
+  fromNodeEvent,
+  fromPromise
 };

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -1,4 +1,0 @@
-/**
- * Void function. Used for providing a NOOP function to a handler.
- */
-export const noop = (): void => {};

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -1,0 +1,4 @@
+/**
+ * Void function. Used for providing a NOOP function to a handler.
+ */
+export const noop = (): void => {};

--- a/tests/helpers/fromDOMEvent.test.ts
+++ b/tests/helpers/fromDOMEvent.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fromDOMEvent } from "rythe/helpers";
+import { isStream } from "rythe/stream";
+import { StreamState } from "rythe/constants";
+
+describe("fromDOMEvent", () => {
+  it("should return a stream", () => {
+    const element = document.createElement("div");
+    const s = fromDOMEvent(element, "click");
+    expect(isStream(s)).toBe(true);
+    expect(s.state).toBe(StreamState.PENDING);
+  });
+  it("should resolve events from a single DOM element", () => {
+    const element = document.createElement("div");
+    const s = fromDOMEvent(element, "click");
+    const clickEvent = new Event("click");
+    element.dispatchEvent(clickEvent);
+
+    expect(s()).toBe(clickEvent);
+    expect(s().type).toBe("click");
+    expect(s().target).toBe(element);
+    expect(s.state).toBe(StreamState.ACTIVE);
+  });
+  it("should resolve events from many DOM elements", () => {
+    const element = document.createElement("div");
+    element.innerHTML = "<div></div><div></div>";
+    const elements = element.children;
+    const s = fromDOMEvent(elements, "click");
+    const clickEvent = new Event("click");
+    element.children[1].dispatchEvent(clickEvent);
+
+    expect(s()).toBe(clickEvent);
+    expect(s().target).toBe(element.children[1]);
+    expect(s.state).toBe(StreamState.ACTIVE);
+  });
+  it("should remove its event listener from a single DOM element on END", () => {
+    const element = document.createElement("div");
+    const s = fromDOMEvent(element, "click");
+
+    s.end(true);
+
+    const clickEvent = new Event("click");
+    element.dispatchEvent(clickEvent);
+
+    expect(s()).toBeUndefined();
+    expect(s.state).toBe(StreamState.CLOSED);
+  });
+  it("should remove its event listener from many DOM elements on END", () => {
+    const element = document.createElement("div");
+    element.innerHTML = "<div></div><div></div>";
+    const elements = element.children;
+    const s = fromDOMEvent(elements, "click");
+
+    s.end(true);
+
+    const clickEvent = new Event("click");
+    element.children[1].dispatchEvent(clickEvent);
+
+    expect(s()).toBeUndefined();
+    expect(s.state).toBe(StreamState.CLOSED);
+  });
+});

--- a/tests/helpers/fromNodeEvent.test.ts
+++ b/tests/helpers/fromNodeEvent.test.ts
@@ -1,0 +1,28 @@
+import { fromNodeEvent } from "rythe/helpers";
+import { isStream } from "rythe/stream";
+import { StreamState } from "rythe/constants";
+import { EventEmitter } from "events";
+
+describe("fromNodeEvent", () => {
+  it("returns a Stream", () => {
+    const events = new EventEmitter();
+    const s = fromNodeEvent(events, "test");
+    expect(isStream(s)).toBe(true);
+    expect(s.state).toBe(StreamState.PENDING);
+    expect(events.listenerCount("test")).toBe(1);
+  });
+  it("resolves data from the emitter", () => {
+    const events = new EventEmitter();
+    const s = fromNodeEvent(events, "test");
+    events.emit("test", "foo");
+    expect(s()).toBe("foo");
+    expect(s.state).toBe(StreamState.ACTIVE);
+  });
+  it("removes its listeners when the stream is closed", () => {
+    const events = new EventEmitter();
+    const s = fromNodeEvent(events, "test");
+    expect(events.listenerCount("test")).toBe(1);
+    s.end(true);
+    expect(events.listenerCount("test")).toBe(0);
+  });
+});

--- a/tests/helpers/fromPromise.test.ts
+++ b/tests/helpers/fromPromise.test.ts
@@ -1,0 +1,59 @@
+import { fromPromise } from "rythe/helpers";
+import { isStream } from "rythe/stream";
+import { StreamState } from "rythe/constants";
+
+const delay = <T>(ms: number, value?: T, fail?: true) =>
+  new Promise<T>((resolve, reject) =>
+    setTimeout(fail ? reject : resolve, ms, value)
+  );
+
+jest.useFakeTimers();
+
+describe("fromPromise", () => {
+  it("should return a Stream that is waiting for the Promise to resolve", () => {
+    const p = delay(100);
+    const s = fromPromise(p);
+    expect(isStream(s)).toBe(true);
+    expect(s.state).toBe(StreamState.PENDING);
+  });
+  it("should return the resolved value and close once done", async () => {
+    const p = delay(100, "foo");
+    const s = fromPromise(p);
+
+    expect(s()).toBeUndefined();
+    expect(s.state).toBe(StreamState.PENDING);
+
+    jest.runAllTimers();
+    await p;
+    expect(s()).toBe("foo");
+    expect(s.state).toBe(StreamState.CLOSED);
+  });
+  it("should close if the Promise rejects", async () => {
+    const p = delay(100, "Error", true);
+    const s = fromPromise(p);
+    try {
+      expect(s.state).toBe(StreamState.PENDING);
+      jest.runAllTimers();
+      await p;
+    } catch (e) {
+      expect(e).toBe("Error");
+      expect(s()).toBe(undefined);
+      expect(s.state).toBe(StreamState.CLOSED);
+    }
+  });
+  it("should accept an error handler function to catch errors from the Promise", async () => {
+    const errorFn = jest.fn();
+    const p = delay(100, "Error", true);
+    const s = fromPromise(p, errorFn);
+    try {
+      expect(s.state).toBe(StreamState.PENDING);
+      jest.runAllTimers();
+      await p;
+    } catch (e) {
+      expect(e).toBe("Error");
+      expect(errorFn).toBeCalledTimes(1);
+      expect(errorFn).toBeCalledWith("Error");
+      expect(s.state).toBe(StreamState.CLOSED);
+    }
+  });
+});

--- a/tests/helpers/fromPromise.test.ts
+++ b/tests/helpers/fromPromise.test.ts
@@ -17,6 +17,7 @@ describe("fromPromise", () => {
     expect(s.state).toBe(StreamState.PENDING);
   });
   it("should return the resolved value and close once done", async () => {
+    expect.assertions(4);
     const p = delay(100, "foo");
     const s = fromPromise(p);
 
@@ -26,9 +27,11 @@ describe("fromPromise", () => {
     jest.runAllTimers();
     await p;
     expect(s()).toBe("foo");
+    await p;
     expect(s.state).toBe(StreamState.CLOSED);
   });
   it("should close if the Promise rejects", async () => {
+    expect.assertions(4);
     const p = delay(100, "Error", true);
     const s = fromPromise(p);
     try {
@@ -38,21 +41,6 @@ describe("fromPromise", () => {
     } catch (e) {
       expect(e).toBe("Error");
       expect(s()).toBe(undefined);
-      expect(s.state).toBe(StreamState.CLOSED);
-    }
-  });
-  it("should accept an error handler function to catch errors from the Promise", async () => {
-    const errorFn = jest.fn();
-    const p = delay(100, "Error", true);
-    const s = fromPromise(p, errorFn);
-    try {
-      expect(s.state).toBe(StreamState.PENDING);
-      jest.runAllTimers();
-      await p;
-    } catch (e) {
-      expect(e).toBe("Error");
-      expect(errorFn).toBeCalledTimes(1);
-      expect(errorFn).toBeCalledWith("Error");
       expect(s.state).toBe(StreamState.CLOSED);
     }
   });


### PR DESCRIPTION
Adding some helper functions to make it easier to interface with DOM or Node events or with Promises. The event helpers are separated so to only be loading code relevant for the use case, as in with Browser events or Node events. This way, only the code needed should be bundled for the given use case and not anything more.