### PR TITLE
Additional Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ stream(5)(6); // mapped emits only 125, 6 is filtered out
 
 ## Goals
 * Provide a tree-shakeable FRP library for use with bundlers like Rollup
-* Have better performance while providing similar ergonomics/API to libraries like Flyd, RxJS
+* Have good performance while providing similar ergonomics/API to libraries like Flyd, RxJS
 * Make use of Typescript as the implementation language for the library for better type documentation and interfaces
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1104,9 +1104,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.3.tgz",
-      "integrity": "sha512-zkOxCS/fA+3SsdA+9Yun0iANxzhQRiNwTvJSr6N95JhuJ/x27z9G2URx1Jpt3zYFfCGUXZGL5UDxt5eyLE7wgw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
+      "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -5905,9 +5905,9 @@
       }
     },
     "rollup": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.12.5.tgz",
-      "integrity": "sha512-XF5YdpeKX4ueGpBCW07AxPJJHu7SHaobYzu2lZnMPX908Ely2LZF0a0EQPgb+iVy5kP4cb4QT3nXIAnyAxpL3A==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.13.1.tgz",
+      "integrity": "sha512-TWBmVU5WS4wOy5Ij2qxrJYRUn/keECvStcXDpJSwgr95JZ6VFf1PDewiAk4VPf5vxr7drRJlxh9kYpxHveYOOg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.17.1",
     "rimraf": "^2.6.3",
-    "rollup": "^1.12.5",
+    "rollup": "^1.13.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-terser": "^5.0.0",
     "rollup-plugin-typescript2": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf ./dist/*",
     "test": "npm-run-all test:lint test:unit",
     "test:lint": "eslint \"./+(src|tests)/**/*.ts\" --cache --cache-location \"./.rpt2_cache/\"",
-    "test:unit": "jest --all --coverage --maxWorkers=3",
+    "test:unit": "jest --all --coverage --maxWorkers=4",
     "clear:test": "jest --clearCache",
     "tsc:help": "tsc -h --all",
     "watch": "jest --watch",

--- a/src/dispatchers/dispatcherHelpers.ts
+++ b/src/dispatchers/dispatcherHelpers.ts
@@ -3,7 +3,8 @@ import { Stream } from "../types";
 
 const { ACTIVE, CHANGING, PENDING } = StreamState;
 
-export const isReady = (stream: Stream<any>): boolean => !(stream.waiting -= 1);
+export const isReady = (stream: Stream<any>): boolean =>
+  !stream.waiting || !(stream.waiting -= 1);
 
 /** Mark a Stream as ACTIVE */
 export const markActive = (stream: Stream<any>): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 import { createStream, isStream } from "./stream";
 import { StreamState } from "./constants";
-import { combine, dropRepeats, filter, map, scan } from "./operators/index";
+import {
+  combine,
+  dropRepeats,
+  dropWith,
+  endsWith,
+  filter,
+  map,
+  scan
+} from "./operators/index";
 import { END, SKIP } from "./signal";
 import { Stream, StreamFn, DependentTuple } from "./types";
 import { fromDOMEvent, fromNodeEvent, fromPromise } from "./helpers";
@@ -11,6 +19,8 @@ export {
   StreamState,
   combine,
   dropRepeats,
+  dropWith,
+  endsWith,
   filter,
   scan,
   map,

--- a/src/operators/dropRepeats.ts
+++ b/src/operators/dropRepeats.ts
@@ -1,11 +1,10 @@
-import { SKIP } from "../signal";
 import { Stream } from "../types";
-import { map } from "./map";
+import { dropWith } from "./dropWith";
+
+const directComparison = <T>(prev: T, next: T): boolean => prev === next;
 
 /**
- * Pushes non-repeating values. Skips any repeated values.
+ * Pushes non-repeating values via direct comparison `prev === next`. Skips any repeated values.
  */
-export const dropRepeats = <T>(source: Stream<T>): Stream<T> => {
-  let prev: T;
-  return map<T>((next): T => (next !== prev ? (prev = next) : SKIP))(source);
-};
+export const dropRepeats = <T>(source: Stream<T>): Stream<T> =>
+  dropWith<T>(directComparison)(source);

--- a/src/operators/dropWith.ts
+++ b/src/operators/dropWith.ts
@@ -1,0 +1,15 @@
+import { SKIP } from "../signal";
+import { Stream, OperatorFn } from "../types";
+import { map } from "./map";
+
+/**
+ * Pushes non-repeating values using a predicate function. Skips any repeated values.
+ */
+export const dropWith = <T>(
+  predicate: (prev: T | undefined, next: T) => boolean
+): OperatorFn<T, T> => (source: Stream<T>): Stream<T> => {
+  let prev: T | undefined;
+  return map<T>((value): T => (predicate(prev, value) ? SKIP : (prev = value)))(
+    source
+  );
+};

--- a/src/operators/endsWith.ts
+++ b/src/operators/endsWith.ts
@@ -1,0 +1,11 @@
+import { Stream, OperatorFn } from "../types";
+import { subscriber } from "../utils/subscriber";
+import { END } from "../signal";
+
+const killFn = (): any => END;
+
+export function endsWith<T>(end: Stream<any>): OperatorFn<any, T>;
+
+export function endsWith(end: Stream<any>): OperatorFn<any, any> {
+  return <T>(stream: Stream<T>): Stream<T> => subscriber(stream, end, killFn);
+}

--- a/src/operators/endsWith.ts
+++ b/src/operators/endsWith.ts
@@ -6,6 +6,9 @@ const killFn = (): any => END;
 
 export function endsWith<T>(end: Stream<any>): OperatorFn<any, T>;
 
+/**
+ * Ends a Stream using another Stream's invocation.
+ */
 export function endsWith(end: Stream<any>): OperatorFn<any, any> {
   return <T>(stream: Stream<T>): Stream<T> => subscriber(stream, end, killFn);
 }

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -3,5 +3,6 @@ import { dropRepeats } from "./dropRepeats";
 import { filter } from "./filter";
 import { map } from "./map";
 import { scan } from "./scan";
+import { endsWith } from "./endsWith";
 
-export { combine, dropRepeats, filter, map, scan };
+export { combine, dropRepeats, endsWith, filter, map, scan };

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,8 +1,9 @@
 import { combine } from "./combine";
+import { dropWith } from "./dropWith";
 import { dropRepeats } from "./dropRepeats";
 import { filter } from "./filter";
 import { map } from "./map";
 import { scan } from "./scan";
 import { endsWith } from "./endsWith";
 
-export { combine, dropRepeats, endsWith, filter, map, scan };
+export { combine, dropRepeats, dropWith, endsWith, filter, map, scan };

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -2,6 +2,7 @@ import { createStream, isStream } from "../stream";
 import { StreamState, StreamError } from "../constants";
 import { SKIP } from "../signal";
 import { Stream, OperatorFn } from "../types";
+import { subscriber } from "../utils/subscriber";
 
 const { ACTIVE, PENDING } = StreamState;
 
@@ -24,7 +25,7 @@ export function map<T>(
   ignoreInitial?: SKIP
 ): OperatorFn<any, any> {
   return (source: Stream<any>): Stream<any> => {
-    const { state, dependents, val } = source;
+    const { state, val } = source;
     if (!isStream(source)) {
       throw new Error(StreamError.SOURCE_ERROR);
     }
@@ -34,8 +35,6 @@ export function map<T>(
     } else if (state === PENDING) {
       mapStream.waiting = 1;
     }
-    dependents.push([mapStream, mapFn]);
-    mapStream.parents = source;
-    return mapStream;
+    return subscriber(mapStream, source, mapFn);
   };
 }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -11,6 +11,3 @@ export const SKIP: SKIP = freeze(create(null));
  * END. Used for signalling a Stream to close itself when passed as a parameter.
  */
 export const END: END = freeze(create(null));
-
-export const isSignal = (value: any): boolean =>
-  value === SKIP || value === END;

--- a/src/utils/subscriber.ts
+++ b/src/utils/subscriber.ts
@@ -1,0 +1,18 @@
+import { Stream, StreamFn } from "../types";
+
+export const subscriber = <T, U>(
+  stream: Stream<U>,
+  parent: Stream<T>,
+  subscribeFn: StreamFn<T, U>
+): Stream<U> => {
+  parent.dependents.push([stream, subscribeFn]);
+  const currentParents = stream.parents;
+  if (!currentParents) {
+    stream.parents = parent;
+  } else if (Array.isArray(currentParents)) {
+    currentParents.push(parent);
+  } else {
+    stream.parents = [currentParents, parent];
+  }
+  return stream;
+};

--- a/tests/operators/dropWith.test.ts
+++ b/tests/operators/dropWith.test.ts
@@ -1,0 +1,24 @@
+import { createStream } from "rythe/stream";
+import { dropWith, map } from "rythe/operators";
+
+it("will not pass down repeat values according to its predicate function", () => {
+  const a = createStream<any>();
+  const mapFn = jest.fn((n: any) => n);
+  const m = a.pipe(
+    dropWith<any>((prev, next) => prev && prev.val === next.val),
+    map(mapFn)
+  );
+  a({ val: 1 })({ val: 1 })({ val: 2 })({ val: 2 })({ val: 2 })({ val: 3 });
+  expect(m()).toEqual({ val: 3 });
+  expect(mapFn).toBeCalledTimes(3);
+});
+it("passes down initial value immediately", () => {
+  const a = createStream<any>({ val: 1 });
+  const mapFn = jest.fn((n: any) => n);
+  const m = a.pipe(
+    dropWith<any>((prev, next) => prev && prev.val === next.val),
+    map(mapFn)
+  );
+  expect(m()).toEqual({ val: 1 });
+  expect(mapFn).toBeCalledTimes(1);
+});

--- a/tests/operators/endsWith.test.ts
+++ b/tests/operators/endsWith.test.ts
@@ -1,0 +1,24 @@
+import { createStream } from "rythe/stream";
+import { StreamState } from "rythe/constants";
+import { endsWith } from "rythe/operators";
+
+describe("endsWith", () => {
+  it("subscribes an existing Stream to another", () => {
+    const a = createStream<number>();
+    const b = createStream<string>();
+    expect(a.dependents.length).toBe(0);
+    expect(a.parents).toBe(null);
+    endsWith<string>(a)(b);
+    expect(b.parents).toBe(a);
+  });
+  it("subscribed Streams get ended by updates from the parent Stream", () => {
+    const a = createStream<number>();
+    const killer = createStream<string>();
+    endsWith<string>(killer)(a);
+    a(5)(6);
+    expect(a.state).toBe(StreamState.ACTIVE);
+    expect(killer.dependents[0][0]).toBe(a);
+    killer("Do it!");
+    expect(a.state).toBe(StreamState.CLOSED);
+  });
+});

--- a/tests/utils/subscriber.test.ts
+++ b/tests/utils/subscriber.test.ts
@@ -1,0 +1,30 @@
+import { createStream } from "rythe/stream";
+import { combine, map } from "rythe/operators";
+import { END } from "rythe/signal";
+import { subscriber } from "rythe/utils/subscriber";
+
+describe("subscriber", () => {
+  it("subscribes a stream with no parents", () => {
+    const a = createStream<number>();
+    const b = createStream<string>();
+    expect(a.dependents.length).toBe(0);
+    expect(a.parents).toBe(null);
+    subscriber<number, string>(b, a, (value: number) => value + "");
+    expect(b.parents).toBe(a);
+  });
+  it("subscribes a stream with one parent already", () => {
+    const a = createStream<number>();
+    const b = a.pipe(map(value => value + ""));
+    expect(b.parents).toBe(a);
+    subscriber(b, a.end, () => END);
+    expect(b.parents).toEqual([a, a.end]);
+  });
+  it("subscribes a stream with many parents already", () => {
+    const a = createStream<number>();
+    const b = createStream<number>();
+    const c = combine((sA, sB) => sA() + sB(), [a, b]);
+    expect(c.parents).toEqual([a, b]);
+    subscriber(c, a.end, () => END);
+    expect(c.parents).toEqual([a, b, a.end]);
+  });
+});


### PR DESCRIPTION
Added dropWith and endsWith as operators for Rythe. endsWith should allow for testing the dispatcher to handle passing END signals down to dependents, thus reaching 100% coverage. dropWith allows one to use a predicate function to determine whether a value is equal to its previous version. dropRepeats has been refactored to use dropWith as its underlying implementation.