### PR TITLE
Timers refactor, EndStream type and signature

### DIFF
--- a/src/helpers/every.ts
+++ b/src/helpers/every.ts
@@ -1,18 +1,11 @@
 import { createStream } from "../stream";
 import { Stream } from "../types";
 import { map } from "../operators";
-
-const timer = (stream: Stream<number>, duration: number, tick: number) => {
-  const now = Date.now();
-  stream(now);
-  const target = tick + duration;
-  const delta = target - now;
-  return setTimeout(timer, delta, stream, duration, target);
-};
+import { timers } from "../utils/timers";
 
 export const every = (duration = 0): Stream<number> => {
   const stream = createStream<number>();
-  const interval = timer(stream, duration, Date.now());
-  map<boolean, void>(() => clearTimeout(interval))(stream.end);
+  timers.interval(stream, duration, Date.now());
+  map<boolean, void>(() => timers.clear(stream))(stream.end);
   return stream;
 };

--- a/src/operators/endsWith.ts
+++ b/src/operators/endsWith.ts
@@ -1,6 +1,6 @@
 import { Stream, OperatorFn } from "../types";
-import { subscriber } from "../utils/subscriber";
-import { kill } from "../utils/kill";
+import { map } from "./map";
+import { SKIP } from "../signal";
 
 export function endsWith<T>(end: Stream<any>): OperatorFn<any, T>;
 
@@ -8,5 +8,8 @@ export function endsWith<T>(end: Stream<any>): OperatorFn<any, T>;
  * Ends a Stream using another Stream's invocation.
  */
 export function endsWith(end: Stream<any>): OperatorFn<any, any> {
-  return <T>(stream: Stream<T>): Stream<T> => subscriber(stream.end, end, kill);
+  return <T>(stream: Stream<T>): Stream<T> => {
+    map(() => stream.end(true), SKIP)(end);
+    return stream;
+  };
 }

--- a/src/operators/merge.ts
+++ b/src/operators/merge.ts
@@ -2,7 +2,7 @@ import { Stream, StreamValuesFromArray } from "../types";
 import { createStream, isStream } from "../stream";
 import { StreamState, StreamError } from "../constants";
 import { subscriber } from "../utils/subscriber";
-import { kill } from "../utils/kill";
+import { map } from "./map";
 
 const { ACTIVE } = StreamState;
 
@@ -23,7 +23,7 @@ export function merge<
       throw new Error(StreamError.SOURCE_ERROR);
     }
     subscriber(merged, source, passthrough);
-    subscriber(merged.end, source.end, kill);
+    map(merged.end)(source.end);
     if (!immediate && source.state === ACTIVE) {
       immediate = source;
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,6 +1,6 @@
 import { StreamState } from "./constants";
 import { recursiveDispatcher as dispatch } from "./dispatchers/recursiveDispatcher";
-import { Stream, Closer, OperatorFn } from "./types";
+import { Stream, Closer, OperatorFn, EndStream } from "./types";
 import { pipeFromArray } from "./utils/pipe";
 
 const { CLOSED, PENDING } = StreamState;
@@ -74,15 +74,13 @@ export const createStream = <T>(initialValue?: T): Stream<T> => {
     return next;
   } as Stream<T>;
 
-  const complete = function(value: boolean): boolean | Stream<boolean> {
-    if (!arguments.length) {
-      return complete.val;
-    } else if (complete.state && value && typeof value === "boolean") {
+  const complete = function(value: boolean): boolean {
+    if (complete.state && value && typeof value === "boolean") {
       dispatch(complete, value);
       close(next)(complete);
     }
-    return complete;
-  } as Stream<boolean>;
+    return complete.val;
+  } as EndStream;
 
   const stream = initStream<T>(next);
   stream.end = initStream<boolean>(complete);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface Stream<T> {
    * A Stream for ending/completing the parent Stream. Causes all parents/dependents
    * subscriptions to be erased from the Stream, and sets its state to CLOSED.
    */
-  end: Stream<boolean>;
+  end: EndStream;
   /**
    * An Array containing tuple values of Dependent Streams and their value functions.
    * The value functions transform the parent Stream's value to the Dependent Stream's
@@ -155,6 +155,17 @@ export interface Stream<T> {
   ): Stream<any>;
   pipe<U>(...operators: OperatorFn<any, any>[]): Stream<U>;
   toJSON(): any;
+}
+
+export interface EndStream extends Stream<boolean> {
+  /**
+   * Returns the Stream's current value.
+   */
+  (): boolean;
+  /**
+   * Assigns a new value to the Stream and broadcasts it to all its dependencies.
+   */
+  (value: boolean): boolean;
 }
 
 /**

--- a/src/utils/kill.ts
+++ b/src/utils/kill.ts
@@ -1,4 +1,0 @@
-import { END } from "../signal";
-
-/** Function that returns a kill signal. For use with Streams subscribed to .end */
-export const kill = (): any => END;

--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -1,0 +1,21 @@
+const timerStore = new WeakMap<Function, any>();
+
+export const timers = {
+  add(fn: Function, timer: any) {
+    timerStore.set(fn, timer);
+  },
+  clear(fn: Function) {
+    const timer = timerStore.get(fn);
+    if (timer) {
+      clearTimeout(timer);
+      timerStore.delete(fn);
+    }
+  },
+  interval(fn: (timestamp: number) => any, duration: number, tick: number) {
+    fn(tick);
+    const now = Date.now();
+    const target = tick + duration;
+    const delta = target - now;
+    timers.add(fn, setTimeout(timers.interval, delta, fn, duration, target));
+  }
+};

--- a/tests/helpers/every.test.ts
+++ b/tests/helpers/every.test.ts
@@ -29,10 +29,11 @@ describe("every", () => {
     advanceBy(1000);
     jest.advanceTimersByTime(1000);
     expect(s.val).toBe(2);
-    expect(t.val).toBe(now + 1001);
+    expect(t.val).toBe(now + 1000);
     advanceBy(1001);
     jest.advanceTimersByTime(1001);
     expect(s.val).toBe(3);
+    expect(t.val).toBe(now + 2000);
   });
   it("defaults to 0 duration", () => {
     const t = every();

--- a/tests/operators/during.test.ts
+++ b/tests/operators/during.test.ts
@@ -1,9 +1,13 @@
 import { isStream, createStream } from "rythe/stream";
 import { scan, during } from "rythe/operators";
+import { advanceBy, advanceTo } from "jest-date-mock";
 
 jest.useFakeTimers();
 
 describe("during", () => {
+  beforeAll(() => {
+    advanceTo(new Date());
+  });
   afterEach(() => {
     jest.clearAllTimers();
   });
@@ -20,14 +24,17 @@ describe("during", () => {
     a(1)(2)(3);
     expect(d()).toBeUndefined();
     expect(count()).toBe(0);
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
     a(4)(5);
+    advanceBy(50);
     jest.advanceTimersByTime(50);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
     a(6);
+    advanceBy(50);
     jest.advanceTimersByTime(50);
     expect(d()).toEqual([4, 5, 6]);
     expect(count()).toBe(2);
@@ -37,15 +44,18 @@ describe("during", () => {
     const d = a.pipe(during(100));
     const count = d.pipe(scan(num => ++num, 0));
     a(1)(2)(3);
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
     d.end(true);
     a(4)(5);
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
     a(6);
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
@@ -56,10 +66,12 @@ describe("during", () => {
     const count = d.pipe(scan(num => ++num, 0));
     // Updates here
     a(1)(2)(3);
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);
     // No updates here
+    advanceBy(100);
     jest.advanceTimersByTime(100);
     expect(d()).toEqual([1, 2, 3]);
     expect(count()).toBe(1);

--- a/tests/operators/endsWith.test.ts
+++ b/tests/operators/endsWith.test.ts
@@ -9,7 +9,6 @@ describe("endsWith", () => {
     expect(a.dependents.length).toBe(0);
     expect(a.parents).toEqual([]);
     endsWith<string>(a)(b);
-    expect(b.end.parents).toEqual([a]);
   });
   it("subscribed Streams get ended by updates from the parent Stream", () => {
     const a = createStream<number>();
@@ -17,7 +16,6 @@ describe("endsWith", () => {
     endsWith<string>(killer)(a);
     a(5)(6);
     expect(a.state).toBe(StreamState.ACTIVE);
-    expect(killer.dependents[0][0]).toBe(a.end);
     killer("Do it!");
     expect(a.state).toBe(StreamState.CLOSED);
   });

--- a/tests/utils/timers.test.ts
+++ b/tests/utils/timers.test.ts
@@ -1,0 +1,45 @@
+import { advanceBy, advanceTo } from "jest-date-mock";
+import { timers } from "rythe/utils/timers";
+
+jest.useFakeTimers();
+
+describe("timers", () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+  it("adds timers", () => {
+    const mockFn = jest.fn();
+    timers.add(mockFn, setTimeout(mockFn, 10, "foo"));
+    jest.advanceTimersByTime(10);
+    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledWith("foo");
+  });
+  it("clears timers", () => {
+    const mockFn = jest.fn();
+    timers.add(mockFn, setTimeout(mockFn, 10, "foo"));
+    jest.advanceTimersByTime(5);
+    expect(mockFn).toBeCalledTimes(0);
+    timers.clear(mockFn);
+    jest.advanceTimersByTime(10);
+    expect(mockFn).toBeCalledTimes(0);
+  });
+  it("creates self-adjusting interval timers", () => {
+    advanceTo(new Date());
+    const mockFn = jest.fn();
+    const now = Date.now();
+    timers.interval(mockFn, 20, now);
+    // interval executes function once to start at time 0
+    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledWith(now);
+    // Introduce a delay on the next execution
+    advanceBy(25);
+    jest.advanceTimersByTime(20);
+    expect(mockFn).toBeCalledTimes(2);
+    expect(mockFn).toBeCalledWith(now + 20);
+    // Check if the delay is compensated for
+    advanceBy(15);
+    jest.advanceTimersByTime(15);
+    expect(mockFn).toBeCalledTimes(3);
+    expect(mockFn).toBeCalledWith(now + 20 + 20);
+  });
+});


### PR DESCRIPTION
Changed .end to be an EndStream type, which unlike a normal Stream, always returns its value regardless of whether a new value is passed in or not. EndStreams don't curry like normal Streams as they are meant to be 'one-shot' streams. This then allows .end to be used for map functions to do some nifty and terse chaining.

Also refactored timers to be managed by a single module, using WeakMaps to tag timers for easier management of setTimeouts and intervals across multiple operators.